### PR TITLE
Fix proper nouns and update more references from jonaseberle to ddev org

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
 [![Tests](https://github.com/jonaseberle/github-action-setup-ddev/workflows/tests/badge.svg?event=push)](https://github.com/jonaseberle/github-action-setup-ddev/actions)
 
-# Setup and start ddev action
+# Setup and start DDEV action
 
-This **Github action** starts [ddev](https://github.com/drud/ddev/) with your project's configuration from the directory `.ddev`.
+This **GitHub action** starts [DDEV](https://github.com/drud/ddev/) with your project's configuration from the directory `.ddev`.
 
 The idea is to reuse the same environment that you are maintaining for development anyways for automated acceptance testing, thus saving on maintaining a separate CI-configuration.
 
 Any additional services that you might have configured will be started and any post-start hooks etc. will be run.
 
-## Example Github workflow
+## Example GitHub workflow
 
 ```yaml
 on: [push, pull_request]
@@ -30,7 +30,7 @@ jobs:
 
 #### ddevDir
 
-Path to your ddev project.
+Path to your DDEV project.
 
 default: `.` (root directory)
 
@@ -45,7 +45,7 @@ default: `.` (root directory)
 
 #### autostart
 
-Starts your ddev project immediately.
+Starts your DDEV project immediately.
 
 default: `true`
 
@@ -59,7 +59,7 @@ default: `true`
 
 ### SSH keys
 
-If your workflow needs to reach remote destinations that require private SSH keys, here is a snippet showing how you might add SSH keys that you have entered as Github "secrets":
+If your workflow needs to reach remote destinations that require private SSH keys, here is a snippet showing how you might add SSH keys that you have entered as GitHub "secrets":
 
 ```
 - name: Set up SSH keys
@@ -75,6 +75,6 @@ If your workflow needs to reach remote destinations that require private SSH key
 
 ## Contact
 
-For **bugs** and **feature requests** use the [Github bug tracker](https://github.com/jonaseberle/github-action-setup-ddev/issues).
+For **bugs** and **feature requests** use the [GitHub bug tracker](https://github.com/jonaseberle/github-action-setup-ddev/issues).
 
 Pull requests are very welcome.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Tests](https://github.com/jonaseberle/github-action-setup-ddev/workflows/tests/badge.svg?event=push)](https://github.com/jonaseberle/github-action-setup-ddev/actions)
+[![Tests](https://github.com/ddev/github-action-setup-ddev/workflows/tests/badge.svg?event=push)](https://github.com/ddev/github-action-setup-ddev/actions)
 
 # Setup and start DDEV action
 
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-18.04    # tested on: 18.04/20.04
     steps:
       - uses: actions/checkout@v1
-      - uses: jonaseberle/github-action-setup-ddev@v1
+      - uses: ddev/github-action-setup-ddev@v1
       # example: composer install
       - run: ddev composer install
       # example: fill database
@@ -35,7 +35,7 @@ Path to your DDEV project.
 default: `.` (root directory)
 
 ```yaml
-  - uses: jonaseberle/github-action-setup-ddev@v1
+  - uses: ddev/github-action-setup-ddev@v1
     with:
       ddevDir: ".devbox"
   # run `ddev` project commands from that directory
@@ -50,7 +50,7 @@ Starts your DDEV project immediately.
 default: `true`
 
 ```yaml
-  - uses: jonaseberle/github-action-setup-ddev@v1
+  - uses: ddev/github-action-setup-ddev@v1
     with:
       autostart: false
 ```
@@ -70,11 +70,11 @@ If your workflow needs to reach remote destinations that require private SSH key
     chmod 700 .ddev/homeadditions/.ssh
     chmod 600 .ddev/homeadditions/.ssh/id_rsa
 - name: Set up ddev
-  uses: jonaseberle/github-action-setup-ddev@v1
+  uses: ddev/github-action-setup-ddev@v1
 ```
 
 ## Contact
 
-For **bugs** and **feature requests** use the [GitHub bug tracker](https://github.com/jonaseberle/github-action-setup-ddev/issues).
+For **bugs** and **feature requests** use the [GitHub bug tracker](https://github.com/ddev/github-action-setup-ddev/issues).
 
 Pull requests are very welcome.


### PR DESCRIPTION
Minor [proper noun](https://ddev.readthedocs.io/en/stable/developers/writing-style-guide/#writing-style) cleanup for the readme: `ddev` → `DDEV`, and `Github` → `GitHub`.