### PR TITLE
Add workflow for maintaining the v1 via a tag instead of a branch

### DIFF
--- a/.github/workflows/update-main-version.yml
+++ b/.github/workflows/update-main-version.yml
@@ -1,10 +1,10 @@
 name: Update Main Version
-run-name: Move ${{ github.event.inputs.major_version || env.DEFAULT_MAJOR_VERSION }} to ${{ github.event.inputs.target || github.sha }}
+run-name: Move ${{ github.event.inputs.major_version || 'latest tag' }} to ${{ github.event.inputs.target || github.sha }}
 
 on:
   push:
     tags:
-      - v1.**
+      - 'v[0-9]+.**'
   workflow_dispatch:
     inputs:
       target:
@@ -32,7 +32,10 @@ jobs:
       run: |
         git config user.name github-actions
         git config user.email github-actions@github.com
+    - name: Get major version
+      if: ${{ github.event_name === 'push' }}
+      run: echo "MAJOR_VERSION=`echo ${GITHUB_REF#refs/*/} | cut -c1-2`" >> $GITHUB_ENV
     - name: Tag new target
-      run: git tag -f ${{ github.event.inputs.major_version || env.DEFAULT_MAJOR_VERSION }} ${{ github.event.inputs.target || github.sha }}
+      run: git tag -f ${{ github.event.inputs.major_version || env.MAJOR_VERSION }} ${{ github.event.inputs.target || github.sha }}
     - name: Push new tag
-      run: git push origin ${{ github.event.inputs.major_version || env.DEFAULT_MAJOR_VERSION }} --force
+      run: git push origin ${{ github.event.inputs.major_version || env.MAJOR_VERSION }} --force

--- a/.github/workflows/update-main-version.yml
+++ b/.github/workflows/update-main-version.yml
@@ -1,5 +1,5 @@
 name: Update Main Version
-run-name: Move ${{ github.event.inputs.major_version }} to ${{ github.event.inputs.target || github.sha }}
+run-name: Move ${{ github.event.inputs.major_version || env.DEFAULT_MAJOR_VERSION }} to ${{ github.event.inputs.target || github.sha }}
 
 on:
   push:
@@ -13,9 +13,11 @@ on:
       major_version:
         type: choice
         description: The major version to update
-        default: v1
         options:
           - v1
+
+env:
+  DEFAULT_MAJOR_VERSION: 'v1'
 
 jobs:
   tag:
@@ -29,6 +31,7 @@ jobs:
         git config user.name github-actions
         git config user.email github-actions@github.com
     - name: Tag new target
-      run: git tag -f ${{ github.event.inputs.major_version || 'v1' }} ${{ github.event.inputs.target || github.sha }}
+      run: git tag -f ${{ github.event.inputs.major_version || env.DEFAULT_MAJOR_VERSION }} ${{ github.event.inputs.target || github.sha }}
     - name: Push new tag
-      run: git push origin ${{ github.event.inputs.major_version || 'v1' }} --force
+      run: git push origin ${{ github.event.inputs.major_version || env.major_version }} --force
+DEFAULT_MAJOR_VERSION

--- a/.github/workflows/update-main-version.yml
+++ b/.github/workflows/update-main-version.yml
@@ -3,8 +3,8 @@ run-name: Move ${{ github.event.inputs.major_version || env.DEFAULT_MAJOR_VERSIO
 
 on:
   push:
-    branches:
-      - 'main'
+    tags:
+      - v1.**
   workflow_dispatch:
     inputs:
       target:

--- a/.github/workflows/update-main-version.yml
+++ b/.github/workflows/update-main-version.yml
@@ -21,7 +21,9 @@ env:
 
 jobs:
   tag:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-lates
+    tpermissions:
+      contents: write
     steps:
     - uses: actions/checkout@v3
       with:
@@ -33,5 +35,4 @@ jobs:
     - name: Tag new target
       run: git tag -f ${{ github.event.inputs.major_version || env.DEFAULT_MAJOR_VERSION }} ${{ github.event.inputs.target || github.sha }}
     - name: Push new tag
-      run: git push origin ${{ github.event.inputs.major_version || env.major_version }} --force
-DEFAULT_MAJOR_VERSION
+      run: git push origin ${{ github.event.inputs.major_version || env.DEFAULT_MAJOR_VERSION }} --force

--- a/.github/workflows/update-main-version.yml
+++ b/.github/workflows/update-main-version.yml
@@ -1,0 +1,34 @@
+name: Update Main Version
+run-name: Move ${{ github.event.inputs.major_version }} to ${{ github.event.inputs.target || github.sha }}
+
+on:
+  push:
+    branches:
+      - 'main'
+  workflow_dispatch:
+    inputs:
+      target:
+        description: The tag or reference to use
+        required: true
+      major_version:
+        type: choice
+        description: The major version to update
+        default: v1
+        options:
+          - v1
+
+jobs:
+  tag:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+    - name: Git config
+      run: |
+        git config user.name github-actions
+        git config user.email github-actions@github.com
+    - name: Tag new target
+      run: git tag -f ${{ github.event.inputs.major_version || 'v1' }} ${{ github.event.inputs.target || github.sha }}
+    - name: Push new tag
+      run: git push origin ${{ github.event.inputs.major_version || 'v1' }} --force

--- a/.github/workflows/update-main-version.yml
+++ b/.github/workflows/update-main-version.yml
@@ -1,5 +1,5 @@
 name: Update Main Version
-run-name: Move ${{ github.event.inputs.major_version || 'latest tag' }} to ${{ github.event.inputs.target || github.sha }}
+run-name: Move ${{ github.event.inputs.major_version || env.MAJOR_VERSION }} to ${{ github.event.inputs.target || github.sha }}
 
 on:
   push:
@@ -17,12 +17,12 @@ on:
           - v1
 
 env:
-  DEFAULT_MAJOR_VERSION: 'v1'
+  MAJOR_VERSION: 'v1'
 
 jobs:
   tag:
     runs-on: ubuntu-lates
-    tpermissions:
+    permissions:
       contents: write
     steps:
     - uses: actions/checkout@v3
@@ -32,9 +32,9 @@ jobs:
       run: |
         git config user.name github-actions
         git config user.email github-actions@github.com
-    - name: Get major version
-      if: ${{ github.event_name === 'push' }}
-      run: echo "MAJOR_VERSION=`echo ${GITHUB_REF#refs/*/} | cut -c1-2`" >> $GITHUB_ENV
+    #- name: Get major version from tag name
+    #  if: ${{ github.event_name === 'push' }}
+    #  run: echo "MAJOR_VERSION=`echo ${GITHUB_REF#refs/*/} | cut -c1-2`" >> $GITHUB_ENV
     - name: Tag new target
       run: git tag -f ${{ github.event.inputs.major_version || env.MAJOR_VERSION }} ${{ github.event.inputs.target || github.sha }}
     - name: Push new tag


### PR DESCRIPTION
## The Issue

The `v1` version is currently stored in a branch, which mirrors the `main` branch. This branch has to be maintained or PR/merge/pushed to by someone regularly.

## How This PR Solves The Issue

By adding a `v1` *tag* instead of branch, we can automate this process via a workflow. This matches what other projects use:

* https://github.com/actions/checkout/blob/main/.github/workflows/update-main-version.yml
* https://github.com/peter-evans/create-pull-request/blob/main/.github/workflows/update-major-version.yml

## Manual Testing Instructions

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

