### PR TITLE
Newest DDEV no longer has dba container by default

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -71,7 +71,7 @@ function run() {
             cmd = 'ddev --version';
             console.log(cmd);
             yield execShellCommand(cmd);
-            cmd = 'ddev config global --instrumentation-opt-in=false --omit-containers=dba,ddev-ssh-agent';
+            cmd = 'ddev config global --instrumentation-opt-in=false --omit-containers=ddev-ssh-agent';
             console.log(cmd);
             yield execShellCommand(cmd);
             if(autostart){


### PR DESCRIPTION
## The Issue

The dba container no longer exists as per https://github.com/ddev/ddev/pull/4990

## How This PR Solves The Issue

## Manual Testing Instructions

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

