### PR TITLE
Support installing a specific ddev version #13

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,9 +19,9 @@ jobs:
       - name: ddev version
         run: |
           if [[ ${{ matrix.version }} == '1.22.3' ]]; then
-            test $(ddev --version) == 'ddev version v1.22.3'
+            test "$(ddev --version)" == 'ddev version v1.22.3'
           else
-            test $(ddev --version) != 'ddev version v1.22.3'
+            test "$(ddev --version)" != 'ddev version v1.22.3'
           fi
       - name: ddev stopped
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,12 +8,21 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-20.04, ubuntu-22.04]
+        version: ['latest', '1.22.3']
     steps:
       - uses: actions/checkout@v3
       - uses: ./
         with:
           ddevDir: tests/fixtures/ddevProj1
           autostart: false
+          version: ${{ matrix.version }}
+      - name: ddev version
+        run: |
+          if [[ ${{ matrix.version }} == '1.22.3' ]]; then
+            test $(ddev --version) == 'ddev version v1.22.3'
+          else
+            test $(ddev --version) != 'ddev version v1.22.3'
+          fi
       - name: ddev stopped
         run: |
           cd tests/fixtures/ddevProj1

--- a/README.md
+++ b/README.md
@@ -55,6 +55,18 @@ default: `true`
       autostart: false
 ```
 
+#### version
+
+Install a specific ddev version. The version must be available in ddev's apt repository.
+
+default: `latest`
+
+```yaml
+  - uses: ddev/github-action-setup-ddev@v1
+    with:
+      version: 1.22.4
+```
+
 ## Common recipes
 
 ### SSH keys

--- a/action.yml
+++ b/action.yml
@@ -17,3 +17,7 @@ inputs:
     description: 'Start ddev automatically'
     required: false
     default: true
+  version:
+    description: 'Install a specific ddev version, such as 1.22.4'
+    required: false
+    default: 'latest'

--- a/lib/main.js
+++ b/lib/main.js
@@ -65,9 +65,23 @@ function run() {
             cmd = 'echo "deb https://apt.fury.io/drud/ * *" | sudo tee -a /etc/apt/sources.list.d/ddev.list';
             console.log(cmd);
             yield execShellCommand(cmd);
-            cmd = 'sudo apt-get update && sudo apt-get install -y ddev && mkcert -install';
+
+            const version = core.getInput('version') || 'latest';
+            let ddevPackage = 'ddev';
+            if (version !== 'latest') {
+                ddevPackage += `=${version}`;
+            }
+
+            cmd = `sudo apt-get update && sudo apt-get install -y ${ddevPackage} && mkcert -install`;
             console.log(cmd);
             yield execShellCommand(cmd);
+
+            if (version !== 'latest') {
+                cmd = 'sudo apt-mark hold ddev';
+                console.log(cmd);
+                yield execShellCommand(cmd);
+            }
+
             cmd = 'ddev --version';
             console.log(cmd);
             yield execShellCommand(cmd);


### PR DESCRIPTION
## The Issue

See https://github.com/ddev/github-action-setup-ddev/issues/13 and https://github.com/jonaseberle/github-action-setup-ddev/issues/15.

## How This PR Solves The Issue

If version is specified, we pass that to apt and then hold the package so upgrades won't automatically upgrade it.

## Manual Testing Instructions

```
    - name: Install ddev
      uses: deviantintegral/github-action-setup-ddev@set-ddev-version
      with:
        autostart: false
        version: 1.22.3
```

## Automated Testing Overview

This adds a matrix to test both cases for version.