### PR TITLE
Support nektos/act for local GitHub actions testing

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -82,13 +82,20 @@ function run() {
                 yield execShellCommand(cmd);
             }
 
+            // Support local runner https://github.com/nektos/act
+            if (process.env.ACT) {
+                cmd = `sudo chown runner:docker /var/run/docker.sock`;
+                console.log(cmd);
+                yield execShellCommand(cmd);
+            }
+
             cmd = 'ddev --version';
             console.log(cmd);
             yield execShellCommand(cmd);
             cmd = 'ddev config global --instrumentation-opt-in=false --omit-containers=ddev-ssh-agent';
             console.log(cmd);
             yield execShellCommand(cmd);
-            if(autostart){
+            if (autostart){
                 if (ddevDir != '.') {
                     cmd = 'cd ' + ddevDir + ' && ddev start';
                 } else {


### PR DESCRIPTION
## The Issue
Running DDEV with [act](https://github.com/nektos/act) is not currently possible
```
ddev config global --instrumentation-opt-in=false --omit-containers=ddev-ssh-agent
Could not connect to a Docker provider. Please start or install a Docker provider.
```

## How This PR Solves The Issue
See https://github.com/nektos/act/issues/724

## Manual Testing Instructions
Create a new workflow with this action:
```
name: "Test Local Install"

on:
  push:
    branches:
      - master
  pull_request:
    types: [opened, synchronize, reopened]

concurrency:
  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
  cancel-in-progress: true

jobs:
  Test-Local-Install:
    runs-on: ubuntu-latest
    steps:
      - uses: actions/checkout@v4

      - uses: ./.github/actions/github-action-setup-ddev
```

Run act:
```
act -P ubuntu-latest=ghcr.io/catthehacker/ubuntu:runner-latest pull_request
```
## Automated Testing Overview
Modification for locals

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

