### PR TITLE
Fix #23: Use node20 runner instead of EOL node16

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -3,7 +3,7 @@ description: |
   This action installs **DDEV** in your Github Workflow.
 author: 'Jonas Eberle and DDEV contributors'
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'lib/main.js'
 branding:
   icon: cpu

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,10 +10,10 @@
       "license": "GPL v3",
       "dependencies": {
         "@actions/core": "^1.10.0",
-        "@types/node": "^18.16.0"
+        "@types/node": "^20.11.25"
       },
       "engines": {
-        "node": "^18.16.0"
+        "node": "^20.11.0"
       }
     },
     "node_modules/@actions/core": {
@@ -35,9 +35,12 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "18.16.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.16.0.tgz",
-      "integrity": "sha512-BsAaKhB+7X+H4GnSjGhJG9Qi8Tw+inU9nJDwmD5CgOmBLEI6ArdhikpLX7DjbjDRDTbqZzU2LSQNZg8WGPiSZQ=="
+      "version": "20.11.25",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.11.25.tgz",
+      "integrity": "sha512-TBHyJxk2b7HceLVGFcpAUjsa5zIdsPWlR6XHfyGzd0SFu+/NFgQgMAl96MSDZgQDvJAvV6BKsFOrt6zIL09JDw==",
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
     },
     "node_modules/tunnel": {
       "version": "0.0.6",
@@ -47,6 +50,11 @@
       "engines": {
         "node": ">=0.6.11 <=0.7.0 || >=0.7.3"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="
     },
     "node_modules/uuid": {
       "version": "8.3.2",

--- a/package.json
+++ b/package.json
@@ -15,11 +15,11 @@
     "setup"
   ],
   "engines": {
-    "node": "^18.16.0"
+    "node": "^20.11.0"
   },
   "author": "Jonas Eberle",
   "dependencies": {
     "@actions/core": "^1.10.0",
-    "@types/node": "^18.16.0"
+    "@types/node": "^20.11.25"
   }
 }


### PR DESCRIPTION
## The Issue

## How This PR Solves The Issue

Use node20 runner instead of EOL node16

## Manual Testing Instructions

No warns should be given.

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

See https://github.com/ddev/github-action-setup-ddev/actions/runs/8180622047. It has node 16 warnings.
This PR actions shouldn't have any.

## Related Issue Link(s)

https://nodejs.org/en/blog/announcements/nodejs16-eol

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

