### PR TITLE
Fix #27: Update installation of ddev

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -59,13 +59,18 @@ function run() {
             const ddevDir = core.getInput('ddevDir') || '.';
             const autostart = core.getBooleanInput('autostart');
             yield execShellCommand('echo \'dir: ' + __dirname + '\'');
-            let cmd = 'curl -fsSL https://apt.fury.io/drud/gpg.key | sudo apt-key add -';
+            let cmd = 'sudo install -m 0755 -d /etc/apt/keyrings';
             console.log(cmd);
             yield execShellCommand(cmd);
-            cmd = 'echo "deb https://apt.fury.io/drud/ * *" | sudo tee -a /etc/apt/sources.list.d/ddev.list';
+            cmd = 'curl -fsSL https://pkg.ddev.com/apt/gpg.key | gpg --dearmor | sudo tee /etc/apt/keyrings/ddev.gpg > /dev/null';
             console.log(cmd);
             yield execShellCommand(cmd);
-
+            cmd = 'sudo chmod a+r /etc/apt/keyrings/ddev.gpg';
+            console.log(cmd);
+            yield execShellCommand(cmd);
+            cmd = 'echo "deb [signed-by=/etc/apt/keyrings/ddev.gpg] https://pkg.ddev.com/apt/ * *" | sudo tee /etc/apt/sources.list.d/ddev.list >/dev/null';
+            console.log(cmd);
+            yield execShellCommand(cmd);
             const version = core.getInput('version') || 'latest';
             let ddevPackage = 'ddev';
             if (version !== 'latest') {


### PR DESCRIPTION
This is my first PR in a GHA done with JavaScript, so please let me know if something doesn't follow the best practises. 

## The Issue

There is a warning on how ddev is installed, this removes this warning

## Manual Testing Instructions

There is no test information, only check that there are no warning regarding installing the ddev package. If not fixed, the warning would be similar to: 

```shell
W: https://apt.fury.io/drud/dists/*/InRelease: Key is stored in legacy trusted.gpg keyring (/etc/apt/trusted.gpg), see the DEPRECATION section in apt-key(8) for details.
```
## Related Issue Link(s)

#27 

## Release/Deployment Notes

No changes needed besides merging.

