### PR TITLE
Fix #30: Accept errors on apt-get update, to proceed with ddev install

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -72,7 +72,7 @@ function run() {
                 ddevPackage += `=${version}`;
             }
 
-            cmd = `sudo apt-get update && sudo apt-get install -y ${ddevPackage} && mkcert -install`;
+            cmd = `(sudo apt-get update || true) && sudo apt-get install -y ${ddevPackage} && mkcert -install`;
             console.log(cmd);
             yield execShellCommand(cmd);
 


### PR DESCRIPTION
## The Issue

#30 

## How This PR Solves The Issue

It solves the problem by allowing apt-get to proceed even when there is an error in the apt-update

## Manual Testing Instructions

Manual testing is a little hard as it only happens when the GitHub Action is used.

## Automated Testing Overview

No tests added

## Related Issue Link(s)

#30 

## Release/Deployment Notes

No action needed besides new release

