### PR TITLE
Update branch tags only when releases are made

### DIFF
--- a/.github/workflows/update-main-version.yml
+++ b/.github/workflows/update-main-version.yml
@@ -1,41 +1,18 @@
-name: Update Main Version
-run-name: Move ${{ github.event.inputs.major_version || 'latest branch tag' }} to ${{ github.event.inputs.target || github.sha }}
+name: Update release version
+
+permissions:
+   contents: write
 
 on:
-  push:
-    tags:
-      - 'v[0-9]+.**'
-  workflow_dispatch:
-    inputs:
-      target:
-        description: The tag or reference to use
-        required: true
-      major_version:
-        type: choice
-        description: The major version to update
-        options:
-          - v1
-
-env:
-  MAJOR_VERSION: 'v1'
+  release:
+    types: [published]
 
 jobs:
-  tag:
+  update-version:
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
     steps:
-    - uses: actions/checkout@v4
-      with:
-        fetch-depth: 0
-    - name: Git config
-      run: |
-        git config user.name github-actions
-        git config user.email github-actions@github.com
-    #- name: Get major version from tag name
-    #  if: ${{ github.event_name === 'push' }}
-    #  run: echo "MAJOR_VERSION=`echo ${GITHUB_REF#refs/*/} | cut -c1-2`" >> $GITHUB_ENV
-    - name: Tag new target
-      run: git tag -f ${{ github.event.inputs.major_version || env.MAJOR_VERSION }} ${{ github.event.inputs.target || github.sha }}
-    - name: Push new tag
-      run: git push origin ${{ github.event.inputs.major_version || env.MAJOR_VERSION }} --force
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Run release-tagger
+        uses: tj-actions/release-tagger@v4


### PR DESCRIPTION
## The Issue

The `v1` tag that we have that is always updated should only really be updated when a new release is made, and not on every push to main.

## How This PR Solves The Issue

Updates the workflow to use https://github.com/tj-actions/release-tagger to update the `v1` release. This also reduces our custom code.

## Manual Testing Instructions

None

## Automated Testing Overview

None

## Related Issue Link(s)

## Release/Deployment Notes

None, this is an internal workflow change only.

