### PR TITLE
Fix: use node24 runner, update dependencies to node ^24.5.2

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -3,7 +3,7 @@ description: |
   This action installs **DDEV** in your Github Workflow.
 author: 'Jonas Eberle and DDEV contributors'
 runs:
-  using: 'node20'
+  using: 'node24'
   main: 'lib/main.js'
 branding:
   icon: cpu

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,10 +10,10 @@
       "license": "GPL v3",
       "dependencies": {
         "@actions/core": "^1.10.0",
-        "@types/node": "^20.11.25"
+        "@types/node": "^24.5.2"
       },
       "engines": {
-        "node": "^20.11.0"
+        "node": "^24.5.2"
       }
     },
     "node_modules/@actions/core": {
@@ -35,11 +35,12 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "20.11.25",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.11.25.tgz",
-      "integrity": "sha512-TBHyJxk2b7HceLVGFcpAUjsa5zIdsPWlR6XHfyGzd0SFu+/NFgQgMAl96MSDZgQDvJAvV6BKsFOrt6zIL09JDw==",
+      "version": "24.5.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.5.2.tgz",
+      "integrity": "sha512-FYxk1I7wPv3K2XBaoyH2cTnocQEu8AOZ60hPbsyukMPLv5/5qr7V1i8PLHdl6Zf87I+xZXFvPCXYjiTFq+YSDQ==",
+      "license": "MIT",
       "dependencies": {
-        "undici-types": "~5.26.4"
+        "undici-types": "~7.12.0"
       }
     },
     "node_modules/tunnel": {
@@ -52,9 +53,10 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "5.26.5",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="
+      "version": "7.12.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.12.0.tgz",
+      "integrity": "sha512-goOacqME2GYyOZZfb5Lgtu+1IDmAlAEu5xnD3+xTzS10hT0vzpf0SPjkXwAw9Jm+4n/mQGDP3LO8CPbYROeBfQ==",
+      "license": "MIT"
     },
     "node_modules/uuid": {
       "version": "8.3.2",

--- a/package.json
+++ b/package.json
@@ -15,11 +15,11 @@
     "setup"
   ],
   "engines": {
-    "node": "^20.11.0"
+    "node": "^24.5.2"
   },
   "author": "Jonas Eberle",
   "dependencies": {
     "@actions/core": "^1.10.0",
-    "@types/node": "^20.11.25"
+    "@types/node": "^24.5.2"
   }
 }


### PR DESCRIPTION
## The Issue
Node 20 will be [EOL in April of 2026](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/).

## How This PR Solves The Issue
1. Updates package.json (and dependencies in package-lock.json) to use Node 24.5.2.
2. Updates action.yml to use the node24 runner.

## Manual Testing Instructions
No new warnings or errors should be thrown.

## Automated Testing Overview
No new warnings or errors should be thrown.

## Related Issue Link(s)
https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

