### PR TITLE
chore(tests): Restrict repository permissions for the test workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,4 +1,6 @@
 name: tests
+permissions:
+  contents: read
 
 on:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/ddev/github-action-setup-ddev/security/code-scanning/2](https://github.com/ddev/github-action-setup-ddev/security/code-scanning/2)

To fix the problem, explicitly set the minimal required `permissions` for the workflow. Since the workflow does not perform any actions that require write permissions (e.g., it does not comment on PRs, update statuses, or push commits), setting `permissions: contents: read` at the workflow level (the root) is the preferred solution. This restricts the `GITHUB_TOKEN` to read-only access to repository contents, greatly reducing the attack surface.

Specifically, add the following at the top level of `.github/workflows/main.yml`, after the `name:` and before the `on:` block:
```yaml
permissions:
  contents: read
```
No changes are required to the existing jobs or steps, as none are observed to require greater permissions.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
