### PR TITLE
Restore original action name

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -1,4 +1,4 @@
-name: 'Setup DDEV in Github Workflows'
+name: 'Setup DDEV in GitHub Workflows'
 description: 'Set up your GitHub Actions workflow with DDEV'
 author: 'Jonas Eberle and DDEV contributors'
 

--- a/action.yml
+++ b/action.yml
@@ -1,4 +1,4 @@
-name: 'Setup and start DDEV action'
+name: 'Setup DDEV in Github Workflows'
 description: 'Set up your GitHub Actions workflow with DDEV'
 author: 'Jonas Eberle and DDEV contributors'
 


### PR DESCRIPTION
## The Issue

Closes #49

## How This PR Solves The Issue

Restores the original name of the Github Actions which it seems is being used for generating the URL for the Github Actions Marketplace listing instead of the repo url. :facepalm: 

This "regression" was introduced in #46.

## Manual Testing Instructions

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

