### PR TITLE
feat: add testing for DDEV HEAD

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,6 +9,12 @@ on:
     paths-ignore:
       - "**.md"
   workflow_dispatch:
+    inputs:
+      debug_enabled:
+        description: 'Run the build with tmate set "debug_enabled"'
+        type: boolean
+        required: false
+        default: false
   schedule:
     - cron: 0 0 * * *
 
@@ -19,7 +25,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-24.04, ubuntu-24.04-arm]
-        version: ['latest', '1.24.7']
+        version: ['latest', 'head', '1.24.8']
     steps:
       - uses: actions/checkout@v5
       - uses: ./
@@ -27,22 +33,46 @@ jobs:
           ddevDir: tests/fixtures/ddevProj1
           autostart: false
           version: ${{ matrix.version }}
+
+      - name: Setup tmate session
+        if: ${{ github.event_name == 'workflow_dispatch' && inputs.debug_enabled }}
+        uses: mxschmitt/action-tmate@v3
+        with:
+          limit-access-to-actor: true
+
       - name: ddev version
         run: |
-          if [[ ${{ matrix.version }} == '1.24.7' ]]; then
-            test "$(ddev --version)" == 'ddev version v1.24.7'
+          ddev --version
+          if [[ ${{ matrix.version }} == '1.24.8' ]]; then
+            test "$(ddev --version)" == 'ddev version v1.24.8'
           else
-            test "$(ddev --version)" != 'ddev version v1.24.7'
+            test "$(ddev --version)" != 'ddev version v1.24.8'
           fi
+
       - name: ddev stopped
         run: |
           cd tests/fixtures/ddevProj1
           test '"stopped"' = "$(ddev describe --json-output | jq '.raw.status')"
+
       - name: start ddev
         run: |
           cd tests/fixtures/ddevProj1
           ddev start --json-output --skip-confirmation
+
       - name: Mailpit reachable
         run: curl --silent --dump-header - --output /dev/null https://setup-ddev-proj1.ddev.site:8026
+
       - name: "index.html: expected output"
         run: test 'index.html test output' = "$(curl --silent https://setup-ddev-proj1.ddev.site)"
+
+      - name: restart ddev with project_tld=test
+        run: |
+          cd tests/fixtures/ddevProj1
+          ddev config --project-tld=test
+          ddev restart --json-output --skip-confirmation
+
+      - name: Mailpit reachable
+        run: curl --silent --dump-header - --output /dev/null https://setup-ddev-proj1.test:8026
+
+      - name: "index.html: expected output"
+        run: test 'index.html test output' = "$(curl --silent https://setup-ddev-proj1.test)"

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ default: `latest`
 ```yaml
       - uses: ddev/github-action-setup-ddev@v1
         with:
-          version: 1.24.7
+          version: 1.24.8
 ```
 
 ### installScriptUrl
@@ -112,7 +112,7 @@ Example with custom script source:
         uses: ddev/github-action-setup-ddev@v1
         with:
           installScriptUrl: "https://my-company.com/scripts/custom_ddev_install.sh"
-          version: "v1.24.7"
+          version: "v1.24.8"
 ```
 
 ## Common recipes

--- a/action.yml
+++ b/action.yml
@@ -29,19 +29,26 @@ runs:
     - name: Download DDEV install script
       shell: bash
       run: |
-        curl -fsSL --retry 3 --retry-max-time 60 --retry-connrefused \
-             -o /tmp/install_ddev.sh \
-             "${{ inputs.installScriptUrl }}"
+        if [[ '${{ inputs.version }}' == 'head' && '${{ inputs.installScriptUrl }}' == 'https://ddev.com/install.sh' ]]; then
+          SCRIPT_URL="https://raw.githubusercontent.com/ddev/ddev/main/scripts/install_ddev_head.sh"
+          echo "Using head version install script: ${SCRIPT_URL}"
+        else
+          SCRIPT_URL="${{ inputs.installScriptUrl }}"
+        fi
+        curl -fsSL --retry 3 --retry-max-time 60 --retry-connrefused -o /tmp/install_ddev.sh "${SCRIPT_URL}"
 
     - name: Install DDEV
       shell: bash
       run: |
-        if [[ '${{ inputs.version }}' != 'latest' ]]; then
+        if [[ '${{ inputs.version }}' == 'latest' ]]; then
+          VERSION_ARG=""
+          echo "Installing latest stable DDEV version"
+        elif [[ '${{ inputs.version }}' == 'head' ]]; then
+          VERSION_ARG=""
+          echo "Installing DDEV HEAD version"
+        else
           VERSION_ARG="v${{ inputs.version }}"
           echo "Installing DDEV version: ${VERSION_ARG}"
-        else
-          VERSION_ARG=""
-          echo "Installing latest DDEV version"
         fi
         
         # Make installation script executable


### PR DESCRIPTION
## The Issue

We don't have testing in DDEV HEAD, which led to:

- https://github.com/ddev/ddev/issues/7790

## How This PR Solves The Issue

- Adds testing for DDEV HEAD
- Adds `debug_enabled`
- Adds testing for custom `project_tld`

TODO:

- [x] Fix broken `ddev describe -j`, which has `{"level":"info","msg":"Download complete.","time":"2025-11-04T14:16:55+02:00"}` unexpected output
- [x] Fix non working HTTPS in `install_ddev_head.sh`
- [x] Revert changes for `CI=true`, non-tty detection and `ddev-hostname` - all of that works in v1.24.8, but not in v1.24.9
- [x] Make a hotfix release v1.24.10

## Manual Testing Instructions

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

