### PR TITLE
Add sshAgent input to optionally keep ddev-ssh-agent container

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,18 @@ default: `latest`
           version: 1.24.8
 ```
 
+### sshAgent
+
+Keep the `ddev-ssh-agent` container running. Enable this if you need SSH inside DDEV containers, e.g. for `ddev auth ssh`.
+
+default: `false`
+
+```yaml
+      - uses: ddev/github-action-setup-ddev@v1
+        with:
+          sshAgent: true
+```
+
 ### installScriptUrl
 
 URL to the DDEV installation script. This allows you to specify a custom or alternative source for the DDEV installation script.
@@ -135,6 +147,8 @@ we recommend adding SSH keys that you have entered as [GitHub "secrets"](https:/
       - name: Setup DDEV
         uses: ddev/github-action-setup-ddev@v1
 ```
+
+If you need to use `ddev auth ssh`, enable the [`sshAgent`](#sshagent) option to keep the `ddev-ssh-agent` container available.
 
 ## Contact
 

--- a/action.yml
+++ b/action.yml
@@ -18,6 +18,11 @@ inputs:
     required: false
     default: 'latest'
 
+  sshAgent:
+    description: 'Keep the ddev-ssh-agent container. Set to true if you need SSH inside DDEV containers (e.g. for ddev auth ssh).'
+    required: false
+    default: 'false'
+
   installScriptUrl:
     description: 'URL to the DDEV installation script'
     required: true
@@ -55,7 +60,11 @@ runs:
         chmod +x /tmp/install_ddev.sh
         
         /tmp/install_ddev.sh ${VERSION_ARG}
-        ddev config global --instrumentation-opt-in=false --omit-containers=ddev-ssh-agent
+        if [[ '${{ inputs.sshAgent }}' == 'true' ]]; then
+          ddev config global --instrumentation-opt-in=false
+        else
+          ddev config global --instrumentation-opt-in=false --omit-containers=ddev-ssh-agent
+        fi
 
     - name: Start DDEV project
       shell: bash


### PR DESCRIPTION
If you do deployments under DDEV from CI, `ddev auth ssh` is handy.